### PR TITLE
Check _output_array flag in api.web.RequestHandler.write_error

### DIFF
--- a/api/web.py
+++ b/api/web.py
@@ -212,7 +212,10 @@ class RequestHandler(tornado.web.RequestHandler):
 		super(RequestHandler, self).finish(chunk)
 
 	def write_error(self, status_code, **kwargs):
-		self._output = []
+		if self._output_array:
+			self._output = []
+		else:
+			self._output = {}
 		if kwargs.has_key("exc_info"):
 			exc = kwargs['exc_info'][1]
 			if isinstance(exc, APIException):


### PR DESCRIPTION
In some cases `RequestHandler._output` would be set to the wrong type.

I hit this bug when trying to call the `station_song_count` endpoint.
