### PR TITLE
Fix a bug in album art detection

### DIFF
--- a/backend/filemonitor.py
+++ b/backend/filemonitor.py
@@ -204,7 +204,7 @@ def _process_album_art(filename, sids):
 	# There's an ugly bug here where psycopg isn't correctly escaping the path's \ on Windows
 	# So we need to repr() in order to get the proper number of \ and then chop the leading and trailing single-quotes
 	# Nasty bug.  This workaround needs to be more thoroughly tested, admittedly, but appears to work fine on Linux as well.
-	directory = repr(os.path.dirname(filename) + os.sep)[2:-1]
+	directory = repr(os.path.dirname(filename) + os.sep)[1:-1]
 	album_ids = db.c.fetch_list("SELECT album_id FROM r4_songs WHERE song_filename LIKE %s || '%%'", (directory,))
 	if not album_ids or len(album_ids) == 0:
 		return


### PR DESCRIPTION
New album art files were not being assigned to albums and copied into the appropriate location.

Normally, the scanner determines what album a certain art file is for by looking for files in the same directory as the art file and pulling the correct `album_id` from the database.

The database query was using `LIKE 'home/icecast/ocr-all/AlbumName/%'` and was not finding any matching `album_id` because the query was missing the leading slash in the directory name.

This patch will send the directory name with the leading slash in the query, allowing the database to return the appropriate `album_id` for album art.
