### PR TITLE
Change the way art is stored and retrieved

### DIFF
--- a/backend/filemonitor.py
+++ b/backend/filemonitor.py
@@ -227,12 +227,9 @@ def _process_album_art(filename, sids):
 		im_120 = im_original.copy()
 		im_120.thumbnail((120, 120), Image.ANTIALIAS)
 	for album_id in album_ids:
-		im_120.save("%s%s%s_%s_120.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
-		im_240.save("%s%s%s_%s_240.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
-		im_320.save("%s%s%s_%s.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
 		im_120.save("%s%s%s_120.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
 		im_240.save("%s%s%s_240.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
-		im_320.save("%s%s%s.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
+		im_320.save("%s%s%s_320.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
 
 def _disable_file(filename):
 	# aka "delete this off the playlist"

--- a/rainwave/playlist_objects/album.py
+++ b/rainwave/playlist_objects/album.py
@@ -94,9 +94,7 @@ class Album(AssociatedMetadata):
 	def get_art_url(self, album_id, sid = None):
 		if not config.get("album_art_file_path"):
 			return ""
-		elif sid and os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s_%s.jpg" % (sid, album_id))):
-			return "%s/%s_%s" % (config.get("album_art_url_path"), sid, album_id)
-		elif os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s.jpg" % album_id)):
+		elif os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s_320.jpg" % album_id)):
 			return "%s/%s" % (config.get("album_art_url_path"), album_id)
 		return ""
 

--- a/static/js4/albums.js
+++ b/static/js4/albums.js
@@ -24,7 +24,7 @@ var Albums = function() {
 		}
 
 		if (("_album_art" in tgt) && tgt._album_art) {
-			var full_res = $el("img", { "class": "art_image", "src": tgt._album_art + ".jpg" });
+			var full_res = $el("img", { "class": "art_image", "src": tgt._album_art + "_320.jpg" });
 			full_res.onload = function() {
 				tgt.style.backgroundImage = "url(" + full_res.getAttribute("src") + ")";
 			};
@@ -59,7 +59,7 @@ var Albums = function() {
 		else {
 			ac = c.appendChild($el("div", { "class": "art_container" }));
 			if (!MOBILE && window.devicePixelRatio && (window.devicePixelRatio > 1.5)) {
-				ac.style.backgroundImage = "url(" + json.art + ".jpg)";
+				ac.style.backgroundImage = "url(" + json.art + "_320.jpg)";
 			}
 			else {
 				ac.style.backgroundImage = "url(" + json.art + "_" + size + ".jpg)";


### PR DESCRIPTION
This patch was inspired by the album art problem reported [in the forums](http://rainwave.cc/forums/viewtopic.php?t=4172). _Dead or Alive_ has album_id 5, which matches the All channel sid. _Xenogears_ has album_id 120, which matches one of the album art size points.

With this patch, the scanner will store all art without any reference to sid. Each album will have the same art on all channels.

All stored art will always specify art size. Each album will have three art files, <album_id>_120.jpg, <album_id>_240.jpg, and <album_id>_320.jpg. The front-end is modified to look for different art sizes according to these rules.

If you accept this patch, I recommend you delete all the existing stored art and rescan for all art files.
