### PR TITLE
Change the way art is stored and retrieved

### DIFF
--- a/backend/filemonitor.py
+++ b/backend/filemonitor.py
@@ -227,12 +227,10 @@ def _process_album_art(filename, sids):
 		im_120 = im_original.copy()
 		im_120.thumbnail((120, 120), Image.ANTIALIAS)
 	for album_id in album_ids:
-		im_120.save("%s%s%s_%s_120.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
-		im_240.save("%s%s%s_%s_240.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
-		im_320.save("%s%s%s_%s.jpg" % (config.get("album_art_file_path"), os.sep, sids[0], album_id))
-		im_120.save("%s%s%s_120.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
-		im_240.save("%s%s%s_240.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
-		im_320.save("%s%s%s.jpg" % (config.get("album_art_file_path"), os.sep, album_id))
+		for sid in sids:
+			im_120.save("%s%s%s_%s_120.jpg" % (config.get("album_art_file_path"), os.sep, sid, album_id))
+			im_240.save("%s%s%s_%s_240.jpg" % (config.get("album_art_file_path"), os.sep, sid, album_id))
+			im_320.save("%s%s%s_%s_320.jpg" % (config.get("album_art_file_path"), os.sep, sid, album_id))
 
 def _disable_file(filename):
 	# aka "delete this off the playlist"

--- a/rainwave/playlist_objects/album.py
+++ b/rainwave/playlist_objects/album.py
@@ -91,13 +91,11 @@ class Album(AssociatedMetadata):
 		return instance
 
 	@classmethod
-	def get_art_url(self, album_id, sid = None):
+	def get_art_url(self, album_id, sid):
 		if not config.get("album_art_file_path"):
 			return ""
-		elif sid and os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s_%s.jpg" % (sid, album_id))):
+		if os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s_%s_320.jpg" % (sid, album_id))):
 			return "%s/%s_%s" % (config.get("album_art_url_path"), sid, album_id)
-		elif os.path.isfile(os.path.join(config.get("album_art_file_path"), "%s.jpg" % album_id)):
-			return "%s/%s" % (config.get("album_art_url_path"), album_id)
 		return ""
 
 	def __init__(self):

--- a/static/js4/albums.js
+++ b/static/js4/albums.js
@@ -24,7 +24,7 @@ var Albums = function() {
 		}
 
 		if (("_album_art" in tgt) && tgt._album_art) {
-			var full_res = $el("img", { "class": "art_image", "src": tgt._album_art + ".jpg" });
+			var full_res = $el("img", { "class": "art_image", "src": tgt._album_art + "_320.jpg" });
 			full_res.onload = function() {
 				tgt.style.backgroundImage = "url(" + full_res.getAttribute("src") + ")";
 			};
@@ -59,7 +59,7 @@ var Albums = function() {
 		else {
 			ac = c.appendChild($el("div", { "class": "art_container" }));
 			if (!MOBILE && window.devicePixelRatio && (window.devicePixelRatio > 1.5)) {
-				ac.style.backgroundImage = "url(" + json.art + ".jpg)";
+				ac.style.backgroundImage = "url(" + json.art + "_320.jpg)";
 			}
 			else {
 				ac.style.backgroundImage = "url(" + json.art + "_" + size + ".jpg)";


### PR DESCRIPTION
The scanner always saves art files with sid and size in the filename. If an album has different art for two channels, the All channel will have the art that was most recently scanned.

Backend requests for an art url must always specify sid.

Front-end requests for an art url must always specify target size.
