### PR TITLE
Fix album art scanning

### DIFF
--- a/backend/filemonitor.py
+++ b/backend/filemonitor.py
@@ -204,7 +204,7 @@ def _process_album_art(filename, sids):
 	# There's an ugly bug here where psycopg isn't correctly escaping the path's \ on Windows
 	# So we need to repr() in order to get the proper number of \ and then chop the leading and trailing single-quotes
 	# Nasty bug.  This workaround needs to be more thoroughly tested, admittedly, but appears to work fine on Linux as well.
-	directory = repr(os.path.dirname(filename) + os.sep)[1:-1]
+	directory = repr(os.path.dirname(filename) + os.sep).strip("u'")
 	album_ids = db.c.fetch_list("SELECT DISTINCT album_id FROM r4_songs WHERE song_filename LIKE %s || '%%'", (directory,))
 	if not album_ids or len(album_ids) == 0:
 		return


### PR DESCRIPTION
Some recent change has caused the `repr()` line here to produce Unicode strings, such as `u'/home/whatever'`, so chopping the first and last characters no longer worked. I changed it to remove any occurrences of `u` and `'` from both sides of the string.
