### PR TITLE
Prevent scanner from incorrectly disabling songs

### DIFF
--- a/backend/filemonitor.py
+++ b/backend/filemonitor.py
@@ -117,10 +117,13 @@ def _check_codepage_1252(filename):
 		raise PassableScanError("Invalid filename. (possible cp1252 or obscure unicode)")
 
 def _scan_directory(directory, sids):
+	# Normalize and add a trailing separator to the directory name
+	directory = os.path.join(os.path.normpath(directory), "")
+
 	# Windows workaround eww, damnable directory names
 	if os.name == "nt":
-		directory = os.path.normpath(directory).replace("\\", "\\\\")
-	
+		directory = directory.replace("\\", "\\\\")
+
 	songs = db.c.fetch_list("SELECT song_id FROM r4_songs WHERE song_filename LIKE %s || '%%' AND song_verified = TRUE", (directory,))
 	for song_id in songs:
 		# log.debug("scan", "Marking Song ID %s for possible deletion." % song_id)


### PR DESCRIPTION
In cases where there are two music directories and the name of one is a prefix of the other, the scanner would incorrectly disable some songs.

For example, if the scanner picked up a modification event on the directory `/music/Metroid`, it would disable all songs in the directory `/music/MetroidPrime` because it searches the database for any files with a prefix that matches the original directory.

This patch introduces a trailing path separator to the database search so such songs are not disabled.