### PR TITLE
Add support for iOS's <link rel="apple-touch-icon" ...>

### DIFF
--- a/api_requests/index.py
+++ b/api_requests/index.py
@@ -65,6 +65,7 @@ class MainIndex(api.web.HTMLRequest):
 					relays=config.public_relays_json[self.sid],
 					stream_filename=config.get_station(self.sid, "stream_filename"),
 					station_list=config.station_list_json,
+					apple_home_screen_icon=config.get("apple_home_screen_icon"),
 					mobile=self.mobile)
 
 @handle_url("/beta")

--- a/etc/rainwave_dev.conf
+++ b/etc/rainwave_dev.conf
@@ -88,6 +88,9 @@
 	"cookie_domain": "",
 	"phpbb_cookie_name": "phpbb3_",
 
+	"_comment": "Set the icon (png, jpg, etc) used for iPhone's 'Add to Home Screen' bookmark",
+	"apple_home_screen_icon": "",
+
 	"stations": {
 		"1": {
 			"host": "localhost",

--- a/etc/rainwave_reference.conf
+++ b/etc/rainwave_reference.conf
@@ -83,6 +83,9 @@
 	"cookie_domain": "",
 	"phpbb_cookie_name": "phpbb3_",
 
+	"_comment": "Set the icon (png, jpg, etc) used for iPhone's 'Add to Home Screen' bookmark",
+	"apple_home_screen_icon": "",
+
 	"stations": {
 		"1": {
 			"host": "localhost",

--- a/templates/r4_index.html
+++ b/templates/r4_index.html
@@ -5,6 +5,7 @@
 	<meta charset="UTF-8" />
 	<meta name="description" content="{{ site_description }}" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+	<link href="{{ apple_home_screen_icon }}" rel="apple-touch-icon" />
 	<script type="text/javascript">
 		var BOOTSTRAP = {
 				"cookie_domain": "{{ cookie_domain }}",


### PR DESCRIPTION
This should allow rainwave deployments to be bookmarked to the iOS
home screen with an icon configured as 'apple_home_screen_icon'
in the rainwave config file.

---

I haven't tested this myself yet, but I figured I'd start the conversation on getting this feature in.

I listen to rainwave.cc on my phone frequently, and noticed that when bookmarked to the home screen on iOS, it appears as a screencapture of the page. I feel it would be nicer to use the OCRemix logo, assuming such permission to use the logo is available in this case.

As a before-and-after of what I expect it would look like when deployed, here's a screenshot from my iPhone home screen:

![img_4964](https://cloud.githubusercontent.com/assets/131818/6162416/91d39c9c-b237-11e4-989a-042346f4334c.jpg)

Left side is the current ocr.rainwave.cc bookmarked to home screen. Right side is a fake page I made with just the right `<link ...>` using [this image](http://th04.deviantart.com/fs39/300W/f/2008/342/f/e/OCR_Cover_1_by_Tankooni.jpg) as the icon.