### PR TITLE
Add functions to remove all songs on cooldown from request list

### DIFF
--- a/api_requests/request.py
+++ b/api_requests/request.py
@@ -107,6 +107,18 @@ class ClearRequests(APIHandler):
 		self.user.clear_all_requests()
 		self.append("requests", self.user.get_requests(self.sid))
 
+@handle_api_url("clear_requests_on_cooldown")
+class ClearRequestsOnCooldown(APIHandler):
+	description = "Clears all requests from the user's queue that are on a cooldown of 20 minutes or more."
+	login_required = True
+	tunein_required = False
+	unlocked_listener_only = False
+	sync_across_sessions = True
+
+	def post(self):
+		self.user.clear_all_requests_on_cooldown()
+		self.append("requests", self.user.get_requests(self.sid))
+
 @handle_api_url("pause_request_queue")
 class PauseRequestQueue(APIHandler):
 	description = "Stops the user from having their request queue processed while they're listening.  Will remove them from the line."

--- a/rainwave/user.py
+++ b/rainwave/user.py
@@ -280,6 +280,9 @@ class User(object):
 	def clear_all_requests(self):
 		return db.c.update("DELETE FROM r4_request_store WHERE user_id = %s", (self.id,))
 
+	def clear_all_requests_on_cooldown(self):
+		return db.c.update("DELETE FROM r4_request_store JOIN r4_song_sid ON r4_song_sid.song_id = r4_request_store.song_id AND r4_song_sid.sid = r4_request_store.sid WHERE user_id = %s AND song_cool_end - extract(EPOCH FROM now()) > 20 * 60", (self.id,))
+
 	def pause_requests(self):
 		self.remove_from_request_line()
 		if db.c.update("UPDATE phpbb_users SET radio_requests_paused = TRUE WHERE user_id = %s", (self.id,)) != 0:

--- a/rainwave/user.py
+++ b/rainwave/user.py
@@ -281,7 +281,7 @@ class User(object):
 		return db.c.update("DELETE FROM r4_request_store WHERE user_id = %s", (self.id,))
 
 	def clear_all_requests_on_cooldown(self):
-		return db.c.update("DELETE FROM r4_request_store JOIN r4_song_sid ON r4_song_sid.song_id = r4_request_store.song_id AND r4_song_sid.sid = r4_request_store.sid WHERE user_id = %s AND song_cool_end - extract(EPOCH FROM now()) > 20 * 60", (self.id,))
+		return db.c.update("DELETE FROM r4_request_store JOIN r4_song_sid ON r4_song_sid.song_id = r4_request_store.song_id AND r4_song_sid.sid = r4_request_store.sid WHERE user_id = %s AND song_cool_end > %s", (self.id, timestamp() + (20 * 60),))
 
 	def pause_requests(self):
 		self.remove_from_request_line()


### PR DESCRIPTION
Feature to "clean up" your request list from all songs on cooldown, but only those that are on a >20 minutes cooldown. Let me know if it'd be useful or not. We can discuss on Discord.