### PR TITLE
In listener detection, read listener_ip from self

### DIFF
--- a/api_requests/ldetect.py
+++ b/api_requests/ldetect.py
@@ -113,7 +113,7 @@ class AddListener(IcecastHandler):
                 "WHERE user_id = %s",
                 (
                     sid,
-                    self.get_argument("ip"),
+                    self.listener_ip,
                     self.get_argument("client"),
                     self.relay,
                     self.agent,
@@ -125,7 +125,7 @@ class AddListener(IcecastHandler):
                 % (
                     "{:<5}".format(self.user_id),
                     sid,
-                    "{:<15}".format(self.get_argument("ip")),
+                    "{:<15}".format(self.listener_ip),
                     "{:<15}".format(self.relay),
                     "{:<10}".format(self.get_argument("client")),
                     self.agent,
@@ -141,7 +141,7 @@ class AddListener(IcecastHandler):
                 (
                     sid,
                     self.user_id,
-                    self.get_argument("ip"),
+                    self.listener_ip,
                     self.get_argument("client"),
                     self.relay,
                     self.agent,
@@ -152,7 +152,7 @@ class AddListener(IcecastHandler):
                 % (
                     "{:<5}".format(self.user_id),
                     sid,
-                    "{:<15}".format(self.get_argument("ip")),
+                    "{:<15}".format(self.listener_ip),
                     "{:<15}".format(self.relay),
                     "{:<10}".format(self.get_argument("client")),
                     self.agent,
@@ -174,7 +174,7 @@ class AddListener(IcecastHandler):
 
         records = db.c.fetch_list(
             "SELECT listener_id FROM r4_listeners WHERE (listener_ip = %s OR listener_key = %s) AND user_id = 1",
-            (self.get_argument("ip"), self.listen_key),
+            (self.listener_ip, self.listen_key),
         )
         if len(records) == 0:
             db.c.update(
@@ -183,7 +183,7 @@ class AddListener(IcecastHandler):
                 "VALUES (%s, %s, %s, %s, %s, %s, %s)",
                 (
                     sid,
-                    self.get_argument("ip"),
+                    self.listener_ip,
                     1,
                     self.relay,
                     self.get_argument("agent"),
@@ -196,7 +196,7 @@ class AddListener(IcecastHandler):
                 % (
                     "{:<5}".format(self.user_id),
                     sid,
-                    "{:<15}".format(self.get_argument("ip")),
+                    "{:<15}".format(self.listener_ip),
                     "{:<15}".format(self.relay),
                     "{:<10}".format(self.get_argument("client")),
                     self.agent,
@@ -220,7 +220,7 @@ class AddListener(IcecastHandler):
                 "WHERE listener_id = %s",
                 (
                     sid,
-                    self.get_argument("ip"),
+                    self.listener_ip,
                     self.relay,
                     self.get_argument("agent"),
                     self.get_argument("client"),
@@ -233,7 +233,7 @@ class AddListener(IcecastHandler):
                 % (
                     "{:<5}".format(self.user_id),
                     sid,
-                    "{:<15}".format(self.get_argument("ip")),
+                    "{:<15}".format(self.listener_ip),
                     "{:<15}".format(self.relay),
                     "{:<10}".format(self.get_argument("client")),
                     self.agent,


### PR DESCRIPTION
`self.listener_ip` is read from the request argument and set on the object in `post()` before calls to `add_registered()` or `add_anonymous()`, so we don't need to call `get_argument()` over and over again.

I'm about to change the way `self.listener_ip` is detected so we can put Icecast behind a reverse proxy and still know the listener IP address, and I only want to change this in one place.