### PR TITLE
Fix song sorting when requesting favourites

### DIFF
--- a/rainwave/playlist.py
+++ b/rainwave/playlist.py
@@ -442,7 +442,7 @@ def get_favorited_songs_for_requesting(user_id, sid, limit):
     for row in db.c.fetch_all(
         _get_requested_albums_sql()
         + (
-            "SELECT FIRST(r4_song_ratings.song_id ORDER BY song_fave DESC NULLS LAST, random()) AS song_id, r4_songs.album_id, BOOL_OR(r4_song_ratings.song_fave) AS song_fave "
+            "SELECT FIRST(r4_song_ratings.song_id ORDER BY song_fave DESC NULLS LAST, random()) AS song_id, r4_songs.album_id, BOOL_OR(COALESCE(r4_song_ratings.song_fave, FALSE)) AS song_fave "
             "FROM r4_song_sid JOIN r4_songs USING (song_id) "
             "JOIN r4_song_ratings ON "
             "(r4_song_sid.song_id = r4_song_ratings.song_id AND user_id = %s AND (r4_song_ratings.song_fave = TRUE OR r4_song_ratings.song_rating_user >= 4.5)) "


### PR DESCRIPTION
Currently, when a listener uses the "Request Faves" feature, songs where `song_fave = FALSE` will always sort before songs where `song_fave IS NULL`, even though these two values are conceptually the same. As a result, some songs may never get picked when requesting faves.

This change will treat `FALSE` and `NULL` values for `song_fave` as the same for this query.